### PR TITLE
Silence warning on exec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension IPC::System::Simple.
 
+{{NEXT}}
+        * Silence "Statement unlikely to be reached" warning (Karen Etheridge)
+
 1.21  Tue Mar 23 12:08:47 AUSEST 2010
         * TEST: t/win32.t has more sane handling of skipped and
           unimplimented tests.

--- a/lib/IPC/System/Simple.pm
+++ b/lib/IPC/System/Simple.pm
@@ -167,8 +167,11 @@ sub run {
 	# We're throwing our own exception on command not found, so
 	# we don't need a warning from Perl.
 
-	no warnings 'exec';		## no critic
-	CORE::system($command,@args);
+        {
+            # silence 'Statement unlikely to be reached' warning
+            no warnings 'exec';             ## no critic
+            CORE::system($command,@args);
+        }
 
 	return _process_child_error($?,$command,$valid_returns);
 }


### PR DESCRIPTION
This warning appears when running code using IPC::System::Simple as 'prove -W' (among other ways):

Statement unlikely to be reached at /usr/lib/perl5/site_perl/5.8.8/IPC/System/Simple.pm line 390.

This commit silences that warning, as per the docs in 'perldoc perldiag' for this warning.
