### PR TITLE
Avoid calling END{} blocks too many times

### DIFF
--- a/lib/IPC/System/Simple.pm
+++ b/lib/IPC/System/Simple.pm
@@ -12,6 +12,7 @@ use Scalar::Util qw(tainted);
 use Config;
 use constant WINDOWS => ($^O eq 'MSWin32');
 use constant VMS     => ($^O eq 'VMS');
+use B;
 
 BEGIN {
 
@@ -393,6 +394,7 @@ sub capturex {
 		# the parent.
 
 		print {$write_fh} int($!);
+		@{; eval { B::end_av->object_2svref } || [] } = ();
 		exit(-1);
 	}
 

--- a/t/12_systemx.t
+++ b/t/12_systemx.t
@@ -3,13 +3,18 @@ use strict;
 
 use IPC::System::Simple qw(system systemx capture capturex);
 use Config;
-use Test::More tests => 7;
+use Test::More tests => 8;
 
 my $perl_path = $Config{perlpath};
 
 if ($^O ne 'VMS') {
         $perl_path .= $Config{_exe}
                 unless $perl_path =~ m/$Config{_exe}$/i;
+}
+
+my $pid = $$;
+END {
+    is($$, $pid, "END Block Called in main process");
 }
 
 chdir("t");     # Ignore return, since we may already be in t/


### PR DESCRIPTION
capturex will, if execution fails, call END{} blocks one too many times. Suggest adding this fix from http://stackoverflow.com/questions/4307482/how-do-i-disable-end-blocks-in-child-processes