### PR TITLE
Use executable name as a source of taintedness

### DIFF
--- a/t/07_taint.t
+++ b/t/07_taint.t
@@ -17,8 +17,8 @@ use_ok("IPC::System::Simple","run","capture");
 
 chdir("t");     # Ignore return, since we may already be in t/
 
-my $taint = $ENV{(keys(%ENV))[0]} . "foo";	# ."foo" to avoid zero length
-ok(tainted($taint),"Sanity - ENV vars are tainted");
+my $taint = $0 . "foo";	# ."foo" to avoid zero length
+ok(tainted($taint),"Sanity - executable name is tainted");
 
 my $evil_zero = 1 - (length($taint) / length($taint));
 


### PR DESCRIPTION
Test::Simple >= 1.302065 injects variables into the environment. These
are not tainted and caused a random t/07_taint.t test failures.

This patch fixes it by using executable name $0 instead.

https://github.com/pjf/ipc-system-simple/issues/21