### PR TITLE
Add STDIN to tests

### DIFF
--- a/t/02_exit.t
+++ b/t/02_exit.t
@@ -20,7 +20,7 @@ chdir("t");	# Ignore return, since we may already be in t/
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 run($perl_path,"exiter.pl",0);
 seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call

--- a/t/02_exit.t
+++ b/t/02_exit.t
@@ -15,13 +15,22 @@ if ($^O ne 'VMS') {
 use IPC::System::Simple qw(run EXIT_ANY);
 chdir("t");	# Ignore return, since we may already be in t/
 
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 run($perl_path,"exiter.pl",0);
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 ok(1,"Multi-arg implicit zero allowed");
 
 foreach (1..5,250..255) {
 
 	eval {
 		run($perl_path,"exiter.pl",$_);
+		seek($input, 0, 0);
 	};
 
 	like($@, qr/unexpectedly returned exit value $_/ );
@@ -30,12 +39,14 @@ foreach (1..5,250..255) {
 # Single arg tests
 
 run("$perl_path exiter.pl 0");
+seek($input, 0, 0);
 ok(1,"Implicit zero allowed");
 
 foreach (1..5,250..255) {
 
 	eval {
 		run("$perl_path exiter.pl $_");
+		seek($input, 0, 0);
 	};
 
 	like($@, qr/unexpectedly returned exit value $_/ );
@@ -44,13 +55,17 @@ foreach (1..5,250..255) {
 # Testing allowable return values
 
 run([0], "$perl_path exiter.pl 0");
+seek($input, 0, 0);
 ok(1,"Explcit zero allowed");
 
 run([1], "$perl_path exiter.pl 1");
+seek($input, 0, 0);
 ok(1,"Explicit allow of exit status 1");
 
 run([-1], "$perl_path exiter.pl 5");
+seek($input, 0, 0);
 ok(1,"Exit-all emulation via [-1] allowed");
 
 run(EXIT_ANY, "$perl_path exiter.pl 5");
+seek($input, 0, 0);
 ok(1,"Exit-all via EXIT_ANY constant");

--- a/t/03_signal.t
+++ b/t/03_signal.t
@@ -24,11 +24,20 @@ use_ok("IPC::System::Simple","run");
 
 chdir("t");
 
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 run([1],$perl_path,"signaler.pl",0);
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 ok(1);
 
 eval {
 	run([1],$perl_path,"signaler.pl",SIGKILL);
+	seek($input, 0, 0);
 };
 
 like($@, qr/died to signal/);

--- a/t/03_signal.t
+++ b/t/03_signal.t
@@ -29,7 +29,7 @@ chdir("t");
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 run([1],$perl_path,"signaler.pl",0);
 seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call

--- a/t/04_capture.t
+++ b/t/04_capture.t
@@ -25,7 +25,7 @@ chdir("t");
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 # Scalar capture
 

--- a/t/05_multi_capture.t
+++ b/t/05_multi_capture.t
@@ -24,7 +24,7 @@ chdir("t");
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 # The tests below for $/ are left in, even though IPC::System::Simple
 # never touches $/

--- a/t/05_multi_capture.t
+++ b/t/05_multi_capture.t
@@ -19,12 +19,20 @@ if ($^O ne 'VMS') {
 use_ok("IPC::System::Simple","capture");
 chdir("t");
 
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 # The tests below for $/ are left in, even though IPC::System::Simple
 # never touches $/
 
 # Scalar capture
 
 my $output = capture($perl_path,"output.pl",0);
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 ok(1);
 
 is($output,"Hello\nGoodbye\n","Scalar capture");
@@ -33,6 +41,7 @@ is($/,"\n",'$/ intact');
 # List capture
 
 my @output = capture($perl_path,"output.pl",0);
+seek($input, 0, 0);
 ok(1);
 
 is_deeply(\@output,["Hello\n", "Goodbye\n"],"List capture");
@@ -43,6 +52,7 @@ is($/,"\n",'$/ intact');
 {
 	local $/ = "e";
 	my @odd_output = capture($perl_path,"output.pl",0);
+	seek($input, 0, 0);
 	ok(1);
 
 	is_deeply(\@odd_output,["He","llo\nGoodbye","\n"], 'Odd $/ capture');
@@ -60,6 +70,7 @@ is($no_output,undef, "No output from failed command");
 # Running Perl -v
 
 my $perl_output = capture($perl_path,"-v");
+seek($input, 0, 0);
 like($perl_output, qr{Larry Wall}, "perl -v contains Larry");
 
 SKIP: {

--- a/t/07_taint.t
+++ b/t/07_taint.t
@@ -17,6 +17,13 @@ use_ok("IPC::System::Simple","run","capture");
 
 chdir("t");     # Ignore return, since we may already be in t/
 
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 my $taint = $0 . "foo";	# ."foo" to avoid zero length
 ok(tainted($taint),"Sanity - executable name is tainted");
 
@@ -29,29 +36,37 @@ SKIP: {
 	skip('$ENV{PATH} is clean',2) unless tainted $ENV{PATH};
 
 	eval { run("$perl_path exiter.pl 0"); };
+	seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 	like($@,qr{called with tainted environment},"Single-arg, tainted ENV");
 
 	eval { run($perl_path, "exiter.pl", 0); };
+	seek($input, 0, 0);
 	like($@,qr{called with tainted environment},"Multi-arg, tainted ENV");
 }
 
 delete @ENV{qw(PATH IFS CDPATH ENV BASH_ENV PERL5SHELL DCL$PATH)};
 
 eval { run("$perl_path exiter.pl $evil_zero"); };
+seek($input, 0, 0);
 like($@,qr{called with tainted argument},"Single-arg, tainted data");
 
 eval { run($perl_path, "exiter.pl", $evil_zero); };
+seek($input, 0, 0);
 like($@,qr{called with tainted argument},"multi-arg, tainted data");
 
 eval { run("$perl_path exiter.pl 0"); };
+seek($input, 0, 0);
 is($@, "", "Single-arg, clean data and ENV");
 
 eval { run($perl_path, "exiter.pl", 0); };
+seek($input, 0, 0);
 is($@, "", "Multi-arg, clean data and ENV");
 
 my $data = eval { capture($perl_path, "exiter.pl", 0) };
+seek($input, 0, 0);
 ok(tainted($data), "Returns of multi-arg capture should be tainted");
 
 $data = eval { capture("$perl_path exiter.pl 0") };
+seek($input, 0, 0);
 ok(tainted($data), "Returns of single-arg capture should be tainted");
 

--- a/t/07_taint.t
+++ b/t/07_taint.t
@@ -22,7 +22,7 @@ chdir("t");     # Ignore return, since we may already be in t/
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 my $taint = $0 . "foo";	# ."foo" to avoid zero length
 ok(tainted($taint),"Sanity - executable name is tainted");

--- a/t/08_core.t
+++ b/t/08_core.t
@@ -41,7 +41,7 @@ chdir("t");
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 my $rlimit_success = setrlimit(RLIMIT_CORE, RLIM_INFINITY, RLIM_INFINITY);
 

--- a/t/08_core.t
+++ b/t/08_core.t
@@ -36,6 +36,13 @@ use_ok("IPC::System::Simple","run");
 
 chdir("t");
 
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 my $rlimit_success = setrlimit(RLIMIT_CORE, RLIM_INFINITY, RLIM_INFINITY);
 
 SKIP: {
@@ -43,6 +50,7 @@ SKIP: {
 
 	eval {
 		run([1],$perl_path, 'signaler.pl', SIGABRT);
+		seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 	};
 
 	like($@, qr/died to signal/, "Signal caught,   \$? = $?");

--- a/t/09_system.t
+++ b/t/09_system.t
@@ -15,16 +15,26 @@ if ($^O ne 'VMS') {
 use IPC::System::Simple qw(system);
 chdir("t");	# Ignore return, since we may already be in t/
 
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 system($perl_path,"exiter.pl",0);
+seek($input, 0, 0);
 ok(1,"Multi-arg system");
 
 system("$perl_path exiter.pl 0");
+seek($input, 0, 0);
 ok(1,"Single-arg system success");
 
 foreach (1..5,250..255) {
 
 	eval {
 		system($perl_path,"exiter.pl",$_);
+		seek($input, 0, 0);
 	};
 
 	like($@, qr/unexpectedly returned exit value $_/, "Multi-arg system fail");
@@ -37,6 +47,7 @@ foreach (1..5,250..255) {
 
 	eval {
 		system("$perl_path exiter.pl $_");
+		seek($input, 0, 0);
 	};
 
 	like($@, qr/unexpectedly returned exit value $_/, "Single-arg system fail" );

--- a/t/09_system.t
+++ b/t/09_system.t
@@ -20,7 +20,7 @@ chdir("t");	# Ignore return, since we may already be in t/
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 system($perl_path,"exiter.pl",0);
 seek($input, 0, 0);

--- a/t/11_newlines.t
+++ b/t/11_newlines.t
@@ -11,20 +11,34 @@ if ($^O ne 'VMS') {
         unless $perl_path =~ m/$Config{_exe}$/i;
 }
 
+chdir("t");	# Ignore return, since we may already be in t/
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 eval { run( "$perl_path -e1" ) };
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 is($@, "", 'Run works with single arg');
 
 eval { run( "$perl_path -e1\n" ) };
+seek($input, 0, 0);
 is($@, "", 'Run works with \\n');
 
 eval { run( "$perl_path -e1\r\n") };
+seek($input, 0, 0);
 is($@, "", 'Run works with \r\n');
 
 eval { capture( "$perl_path -e1" ) };
+seek($input, 0, 0);
 is($@, "", 'Run works with single arg');
 
 eval { capture( "$perl_path -e1\n" ) };
+seek($input, 0, 0);
 is($@, "", 'Run works with \\n');
 
 eval { capture( "$perl_path -e1\r\n") };
+seek($input, 0, 0);
 is($@, "", 'Run works with \r\n');

--- a/t/11_newlines.t
+++ b/t/11_newlines.t
@@ -17,7 +17,7 @@ chdir("t");	# Ignore return, since we may already be in t/
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 eval { run( "$perl_path -e1" ) };
 seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call

--- a/t/12_systemx.t
+++ b/t/12_systemx.t
@@ -19,7 +19,7 @@ chdir("t");     # Ignore return, since we may already be in t/
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 my $exit_test = "$perl_path exiter.pl 0";
 

--- a/t/fail_test.pl
+++ b/t/fail_test.pl
@@ -1,0 +1,10 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+
+#Perl script that prints "Test failed."
+#Intended as a safeguard for testing argument passing, possibly only on Win32
+#If no arguments are given, Perl will wait for input on STDIN.
+#With no input, the test hangs.
+
+print "Test failed.\n";

--- a/t/win32.t
+++ b/t/win32.t
@@ -40,6 +40,13 @@ ok($raw_perl, "Have perl executables with and w/o extensions.");
 
 chdir("t");
 
+#Open a Perl script as backup input. If Perl is called with no arguments, it
+#waits for input on STDIN.
+#This ensures there's data on STDIN so it doesn't hang.
+open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
+my $fileno = fileno($input);
+open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+
 # Check for 16 and 32 bit returns.
 
 foreach my $big_exitval (SMALL_EXIT, BIG_EXIT, HUGE_EXIT) {
@@ -76,41 +83,51 @@ foreach my $big_exitval (SMALL_EXIT, BIG_EXIT, HUGE_EXIT) {
 $ENV{PATH} = "";
 
 eval { run($perl_exe,"-e1"); };
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 like($@,qr/failed to start/,"No calling perl when not in path");
 
 eval { capture($perl_exe,"-e1"); };
+seek($input, 0, 0);
 like($@, qr/failed to start/, "Capture can't find perl when not in path");
 
 eval { run($raw_perl,"-e1"); };
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 like($@, qr/failed to start/, "Can't find raw perl when not in path, either");
 
 $ENV{PATH} = $perl_dir;
 
 run($perl_exe,"-e1");
+seek($input, 0, 0);
 ok(1,"run found perl in path");
 
 run($raw_perl,"-e1");
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 ok(1,"run found raw perl in path");
 
 my $capture = capture($perl_exe,"-v");
+seek($input, 0, 0);
 ok(1,"capture found perl in path");
 like($capture, qr/Larry Wall/, "Capture text successful");
 
 $capture = capture($raw_perl,"-v");
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 ok(1,"capture found raw perl in path");
 like($capture, qr/Larry Wall/, "Capture text successful");
 
 $capture = capture("$perl_exe -v");
+seek($input, 0, 0);
 ok(1,"capture found single-arg perl in path");
 like($capture, qr/Larry Wall/, "Single-arg Capture text successful");
 
 $capture = capture("$raw_perl -v");
+seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
 ok(1,"capture found single-arg raw perl in path");
 like($capture, qr/Larry Wall/, "Single-arg Capture text successful");
 
 $ENV{PATH} = "$ENV{SystemRoot};$perl_dir;$ENV{SystemRoot}\\System32";
 
 run($perl_exe,"-e1");
+seek($input, 0, 0);
 ok(1,"perl found in multi-part path");
 
 run($raw_perl,"-e1");

--- a/t/win32.t
+++ b/t/win32.t
@@ -45,7 +45,7 @@ chdir("t");
 #This ensures there's data on STDIN so it doesn't hang.
 open my $input, '<', 'fail_test.pl' or die "Couldn't open perl script - $!";
 my $fileno = fileno($input);
-open STDIN, "<&$fileno" or die "Couldn't dup - $!";
+open STDIN, "<&", $fileno or die "Couldn't dup - $!";
 
 # Check for 16 and 32 bit returns.
 
@@ -91,7 +91,7 @@ seek($input, 0, 0);
 like($@, qr/failed to start/, "Capture can't find perl when not in path");
 
 eval { run($raw_perl,"-e1"); };
-seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
+seek($input, 0, 0);
 like($@, qr/failed to start/, "Can't find raw perl when not in path, either");
 
 $ENV{PATH} = $perl_dir;
@@ -101,7 +101,7 @@ seek($input, 0, 0);
 ok(1,"run found perl in path");
 
 run($raw_perl,"-e1");
-seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
+seek($input, 0, 0);
 ok(1,"run found raw perl in path");
 
 my $capture = capture($perl_exe,"-v");
@@ -110,7 +110,7 @@ ok(1,"capture found perl in path");
 like($capture, qr/Larry Wall/, "Capture text successful");
 
 $capture = capture($raw_perl,"-v");
-seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
+seek($input, 0, 0);
 ok(1,"capture found raw perl in path");
 like($capture, qr/Larry Wall/, "Capture text successful");
 
@@ -120,7 +120,7 @@ ok(1,"capture found single-arg perl in path");
 like($capture, qr/Larry Wall/, "Single-arg Capture text successful");
 
 $capture = capture("$raw_perl -v");
-seek($input, 0, 0); #Rewind STDIN. Necessary after every potential Perl call
+seek($input, 0, 0);
 ok(1,"capture found single-arg raw perl in path");
 like($capture, qr/Larry Wall/, "Single-arg Capture text successful");
 
@@ -131,6 +131,7 @@ seek($input, 0, 0);
 ok(1,"perl found in multi-part path");
 
 run($raw_perl,"-e1");
+seek($input, 0, 0);
 ok(1,"raw perl found in multi-part path");
 
 # RT #48319 - capture/capturex could break STDOUT when running


### PR DESCRIPTION
Pass a Perl script (fail_test.pl) through STDIN to each invocation of Perl within the t files. If Perl is called without arguments, it will execute this script and simply print "Test failed.". Without STDIN, it will instead wait for input, which looks like the test hangs.

This doesn't fix issue #32 but it does make the failures more graceful.

I've only tested this on Windows.