### PR TITLE
Win32 Fixes

### DIFF
--- a/t/02_exit.t
+++ b/t/02_exit.t
@@ -29,13 +29,13 @@ foreach (1..5,250..255) {
 
 # Single arg tests
 
-run("$perl_path exiter.pl 0");
+run("\"$perl_path\" exiter.pl 0");
 ok(1,"Implicit zero allowed");
 
 foreach (1..5,250..255) {
 
 	eval {
-		run("$perl_path exiter.pl $_");
+		run("\"$perl_path\" exiter.pl $_");
 	};
 
 	like($@, qr/unexpectedly returned exit value $_/ );
@@ -43,14 +43,14 @@ foreach (1..5,250..255) {
 
 # Testing allowable return values
 
-run([0], "$perl_path exiter.pl 0");
+run([0], "\"$perl_path\" exiter.pl 0");
 ok(1,"Explcit zero allowed");
 
-run([1], "$perl_path exiter.pl 1");
+run([1], "\"$perl_path\" exiter.pl 1");
 ok(1,"Explicit allow of exit status 1");
 
-run([-1], "$perl_path exiter.pl 5");
+run([-1], "\"$perl_path\" exiter.pl 5");
 ok(1,"Exit-all emulation via [-1] allowed");
 
-run(EXIT_ANY, "$perl_path exiter.pl 5");
+run(EXIT_ANY, "\"$perl_path\" exiter.pl 5");
 ok(1,"Exit-all via EXIT_ANY constant");

--- a/t/04_capture.t
+++ b/t/04_capture.t
@@ -15,7 +15,7 @@ if ($^O ne 'VMS') {
 
 # Win32 systems don't support multi-arg pipes.  Our
 # simple captures will begin with single-arg tests.
-my $output_exe = "$perl_path output.pl";
+my $output_exe = "\"$perl_path\" output.pl";
 
 use_ok("IPC::System::Simple","capture");
 chdir("t");

--- a/t/07_taint.t
+++ b/t/07_taint.t
@@ -1,8 +1,14 @@
 #!/usr/bin/perl -wT
 use strict;
-use Test::More tests => 13;
+use Test::More;
 use Scalar::Util qw(tainted);
 use Config;
+
+if (exists $INC{"Portable.pm"}) {
+  plan skip_all => 'Cannot test tainted perlpath under Portable perl';
+} else {
+  plan tests => 13;
+}
 
 my $perl_path = $Config{perlpath};
 

--- a/t/09_system.t
+++ b/t/09_system.t
@@ -18,7 +18,7 @@ chdir("t");	# Ignore return, since we may already be in t/
 system($perl_path,"exiter.pl",0);
 ok(1,"Multi-arg system");
 
-system("$perl_path exiter.pl 0");
+system("\"$perl_path\" exiter.pl 0");
 ok(1,"Single-arg system success");
 
 foreach (1..5,250..255) {
@@ -36,7 +36,7 @@ foreach (1..5,250..255) {
 foreach (1..5,250..255) {
 
 	eval {
-		system("$perl_path exiter.pl $_");
+		system("\"$perl_path\" exiter.pl $_");
 	};
 
 	like($@, qr/unexpectedly returned exit value $_/, "Single-arg system fail" );

--- a/t/11_newlines.t
+++ b/t/11_newlines.t
@@ -11,20 +11,20 @@ if ($^O ne 'VMS') {
         unless $perl_path =~ m/$Config{_exe}$/i;
 }
 
-eval { run( "$perl_path -e1" ) };
+eval { run( "\"$perl_path\" -e1" ) };
 is($@, "", 'Run works with single arg');
 
-eval { run( "$perl_path -e1\n" ) };
+eval { run( "\"$perl_path\" -e1\n" ) };
 is($@, "", 'Run works with \\n');
 
-eval { run( "$perl_path -e1\r\n") };
+eval { run( "\"$perl_path\" -e1\r\n") };
 is($@, "", 'Run works with \r\n');
 
-eval { capture( "$perl_path -e1" ) };
+eval { capture( "\"$perl_path\" -e1" ) };
 is($@, "", 'Run works with single arg');
 
-eval { capture( "$perl_path -e1\n" ) };
+eval { capture( "\"$perl_path\" -e1\n" ) };
 is($@, "", 'Run works with \\n');
 
-eval { capture( "$perl_path -e1\r\n") };
+eval { capture( "\"$perl_path\" -e1\r\n") };
 is($@, "", 'Run works with \r\n');

--- a/t/12_systemx.t
+++ b/t/12_systemx.t
@@ -14,7 +14,7 @@ if ($^O ne 'VMS') {
 
 chdir("t");     # Ignore return, since we may already be in t/
 
-my $exit_test = "$perl_path exiter.pl 0";
+my $exit_test = "\"$perl_path\" exiter.pl 0";
 
 eval {
     system($exit_test);
@@ -32,7 +32,7 @@ eval {
 };
 is($@,"", "multi-arg systemx works");
 
-my $output_test = "$perl_path output.pl";
+my $output_test = "\"$perl_path\" output.pl";
 
 my $output;
 

--- a/t/args.t
+++ b/t/args.t
@@ -71,17 +71,17 @@ for my $spec (
 }
 
 # Make sure redirection works, too.
-my $exit = eval { run "$perl output.pl > $tmp" };
+my $exit = eval { run "\"$perl\" output.pl > $tmp" };
 is $@, "", "Should have no error from run with redirection";
 is $exit, 0, "Should have exit 0 from run with redirection";
 is $slurp->(), "Hello\nGoodbye\n", "Should have redirected text run";
 
-$exit = eval { system "$perl output.pl > $tmp" };
+$exit = eval { system "\"$perl\" output.pl > $tmp" };
 is $@, "", "Should have no error from systemx with redirection";
 is $exit, 0, "Should have exit 0 from systemx with redirection";
 is $slurp->(), "Hello\nGoodbye\n", "Should have redirected text systemx";
 
 # And single-string capture.
-my $output = eval { capture "$perl output.pl" };
+my $output = eval { capture "\"$perl\" output.pl" };
 is $@, "", "Should have no error from single-string capture";
 is $output, "Hello\nGoodbye\n", "Should have output from capture";


### PR DESCRIPTION
this PR fixes various test issues found in #37 

The biggest two are: when running a perl under [Portable](https://metacpan.org/pod/Portable) `$Config{perlpath}` is tainted due to having to compute that path at runtime, meaning the entire `t/07_taint.t` test explodes. Not sure how to fix otherwise, so if Portable is loaded then Ive set it to skip the entire test - better versions welcome.

The other issue is when the perlpath itself contains a space. To fix this, all usages of `$perl_path` when used in single argument mode have been quoted.

These tests have been checked working on a perl 5.30.2 running on Windows 10 under [psperl](https://github.com/genio/psperl) and on a perl 5.20.1 on Debian under perlbrew.

Comments and improvements welcome!