### PR TITLE
skip tainting tests if perl was built without taint support

### DIFF
--- a/t/07_taint.t
+++ b/t/07_taint.t
@@ -1,8 +1,15 @@
 #!/usr/bin/perl -wT
 use strict;
-use Test::More tests => 13;
+use Test::More;
 use Scalar::Util qw(tainted);
 use Config;
+
+if (exists($Config{taint_support}) && not $Config{taint_support}) {
+    plan skip_all => "your perl was built without taint support";
+}
+else {
+    plan tests => 13;
+}
 
 my $perl_path = $Config{perlpath};
 

--- a/t/10_formatting.t
+++ b/t/10_formatting.t
@@ -1,24 +1,30 @@
 #!/usr/bin/perl -wT
 use strict;
 use Test::More tests => 5;
+use Config;
 
 use_ok("IPC::System::Simple","run");
 
 # A formatting bug caused ISS to mention its name twice in
 # diagnostics.  These tests make sure it's fixed.
 
+SKIP: {
+    if (exists($Config{taint_support}) && not $Config{taint_support}) {
+        skip("your perl was built without taint support", 2);
+    }
 
-eval {
-	run($^X);
-};
+    eval {
+        run($^X);
+    };
 
-like($@,qr{^IPC::System::Simple::run called with tainted argument},"Taint pkg only once");
+    like($@,qr{^IPC::System::Simple::run called with tainted argument},"Taint pkg only once");
 
-eval {
-	run(1);
-};
+    eval {
+        run(1);
+    };
 
-like($@,qr{^IPC::System::Simple::run called with tainted environment},"Taint env only once");
+    like($@,qr{^IPC::System::Simple::run called with tainted environment},"Taint env only once");
+}
 
 # Delete everything in %ENV so we can't get taint errors.
 


### PR DESCRIPTION
From Perl 5.35.11 onwards, Configure lets you build a perl without taint support.

These changes skip tests that rely on taint support, so that this distribution can be installed under such a perl.
